### PR TITLE
prepublish build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "gulp test",
     "test-node-0.12": "mocha dist/test -- --harmony",
-    "clean": "gulp clean"
+    "clean": "gulp clean",
+    "prepublish": "gulp dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Unless I'm missing something, I think this will ensure that NPM always gets the latest build when you publish. Should keep things like #55 from happening
