### PR TITLE
created interface for adding custom keywords

### DIFF
--- a/src/lib/Custom.js
+++ b/src/lib/Custom.js
@@ -1,0 +1,24 @@
+import Builder from './Builder';
+import Schema from './Schema';
+
+export default class Custom extends Builder {
+  constructor(keyword, value) {
+    super();
+    this.keyword = keyword;
+    this.value = value;
+  }
+
+  json(context) {
+    context = context || {};
+
+    if (this.value) {
+      context[this.keyword] = Array.isArray(this.value) ? this.value.map(toValue) : toValue(this.value);
+    }
+
+    return context;
+
+    function toValue(value) {
+      return value instanceof Schema ? value.json() : value;
+    }
+  }
+}

--- a/src/lib/Schema.js
+++ b/src/lib/Schema.js
@@ -7,6 +7,7 @@ import AdditionalProperties from './AdditionalProperties';
 import AllOf from './AllOf';
 import AnyOf from './AnyOf';
 import Builder from './Builder';
+import Custom from './Custom';
 import Default from './Default';
 import Definitions from './Definitions';
 import Dependencies from './Dependencies';
@@ -421,6 +422,14 @@ export default class Schema extends Builder {
 		return this.getKeywordValue(Default);
 	}
 
+	custom() {
+		if (arguments.length) {
+			this.addKeyword(new Custom(...arguments));
+			return this;
+		}
+
+		return this.getKeywordValue(Custom);
+	}
 
   save() {
     const context = typeof arguments[0] == 'object' ? arguments[0] : null;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -9,6 +9,7 @@ exports.enum = function () { return schema().enum(...arguments) }
 exports.not = function () { return schema().not(...arguments) }
 exports.oneOf = function () { return schema().oneOf(...arguments) }
 exports.type = function () { return schema().type(...arguments) }
+exports.custom = function () { return schema().custom(...arguments) }
 
 // generic helpers - type wrappers
 exports.array = function () { return schema().array() }

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -595,7 +595,7 @@ describe ('Tests based on standard JSON Schema Test Suite', () => {
   });
 
 	describe('optional keywords', () => {
-		
+
 		describe('format', () => {
 
 			test('format', 'validation of date-time strings', () => {
@@ -643,6 +643,31 @@ describe ('Tests based on standard JSON Schema Test Suite', () => {
 			});
 
 		});
+
+		describe('custom', () => {
+
+			it('custom: adds a new keyword', () => {
+				const schema = json.custom('newkeyword', 1);
+				assert(isEqual(schema.json(), {
+					newkeyword: 1
+				}));
+			})
+
+			it('custom: handles Schema value', () => {
+				const schema = json.custom('newkeyword', json.boolean());
+				assert(isEqual(schema.json(), {
+					newkeyword: {type: 'boolean'}
+				}));
+			})
+
+			it('custom: handles Array of Schemas', () => {
+				const schema = json.custom('newkeyword', [json.boolean(), json.array()]);
+				assert(isEqual(schema.json(), {
+					newkeyword: [{type: 'boolean'}, {type: 'array'}]
+				}));
+			})
+
+		})
 
 	});
 


### PR DESCRIPTION
Enables customization of a json schema at the builder level, rather than requiring a difficult post-build step. This allows for domain-specific tooling, especially to integrate with validators like [AJV](https://github.com/epoberezkin/ajv). This could also be implemented as a base class for many of the current keywords to reduce duplication, but I wanted to follow existing conventions.
